### PR TITLE
use local hyperbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+templates/simple/next.config.js
 templates/simple/glossary
 templates/simple/book
 templates/simple/hyperbook.json

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "dev": "node scripts/watcher.mjs",
     "build": "pnpm -r build",
     "lint": "pnpm -r lint",
+    "hyperbook:build": "pnpm --filter hyperbook build",
     "version-packages": "changeset version",
     "release": "changeset publish",
-    "template:dev": "pnpm --filter hyperbook-simple-template dev",
-    "template:build": "pnpm --filter hyperbook-simple-template build"
+    "website:dev": "cd website && node ../packages/hyperbook/dist/index.js dev",
+    "website:build": "cd website && node ../packages/hyperbook/dist/index.js build"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.4.6",


### PR DESCRIPTION
This is only for the documentation. Currently, we are using the npm version of hyperbook. This changes the version of hyperbook to the current one freshly build for the repo.