### PR TITLE
Fix accidentally-escaped newlines in ABC music demo

### DIFF
--- a/website/en/book/elements/abc-music.md
+++ b/website/en/book/elements/abc-music.md
@@ -26,7 +26,9 @@ K: Emin
 X:1
 T: Cooley's Long
 M: 4/4
-L: 1/8\nR: reel\nK: Emin
+L: 1/8
+R: reel
+K: Emin
 D2|:"Em"EB{c}BA B2 EB|~B2 AB dBAG|"D"FDAD BDAD|FDAD dAFD|
 "Em"EBBA B2 EB|B2 AB defg|"D"afe^c dBAF|1"Em"DEFD E2 D2:|2"Em"DEFD E2 gf||
 |:"Em"eB B2 efge|eB B2 gedB|"D"A2 FA DAFA|A2 FA defg|
@@ -47,7 +49,9 @@ K: Emin
 X:1
 T: Cooley's Long
 M: 4/4
-L: 1/8\nR: reel\nK: Emin
+L: 1/8
+R: reel
+K: Emin
 D2|:"Em"EB{c}BA B2 EB|~B2 AB dBAG|"D"FDAD BDAD|FDAD dAFD|
 "Em"EBBA B2 EB|B2 AB defg|"D"afe^c dBAF|1"Em"DEFD E2 D2:|2"Em"DEFD E2 gf||
 |:"Em"eB B2 efge|eB B2 gedB|"D"A2 FA DAFA|A2 FA defg|


### PR DESCRIPTION
Firstly, I love this compilation of libre educational tools into an easy-to-deliver notebook format!

I noticed the key signature of "Cooley's Long" in https://hyperbook.openpatch.org/elements/abc-music was not being recognised, and neither was the subtitle "reel". This is because the lines defining these were not added as new lines, but instead with "\n" instead of the new line character.

This PR fixes that.